### PR TITLE
chore: add commit-before on action.yml

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
         run: cat ./package.json
       - name: 'Automated Version Bump'
         id: version-bump
-        uses: 'phips28/gh-action-bump-version@master'
+        uses: 'alphaprime-dev/gh-action-bump-version@master'
         with:
           tag-prefix: 'v'
         env:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Remove the 'actions/setup-node@v1' step from your action.yml file
 Customize the messages that trigger the version bump. It must be a string, case sensitive, coma separated  (optional). Example:
 ```yaml
 - name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+  uses:  'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -54,7 +54,7 @@ Customize the messages that trigger the version bump. It must be a string, case 
 Set a default version bump to use  (optional - defaults to patch). Example:
 ```yaml
 - name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+  uses:  'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -65,7 +65,7 @@ Set a default version bump to use  (optional - defaults to patch). Example:
 Set a preid value will building prerelease version  (optional - defaults to 'rc'). Example:
 ```yaml
 - name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+  uses:  'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -77,7 +77,7 @@ Set a preid value will building prerelease version  (optional - defaults to 'rc'
 Prefix that is used for the git tag  (optional). Example:
 ```yaml
 - name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+  uses:  'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -88,7 +88,7 @@ Prefix that is used for the git tag  (optional). Example:
 The tag is not added to the git repository  (optional). Example:
 ```yaml
 - name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+  uses:  'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -99,7 +99,7 @@ The tag is not added to the git repository  (optional). Example:
 No commit is made after the version is bumped (optional). Must be used in combination with `skip-tag`, since if there's no commit, there's nothing to tag. Example:
 ```yaml
 - name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+  uses:  'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -111,7 +111,7 @@ No commit is made after the version is bumped (optional). Must be used in combin
 If true, skip pushing any commits or tags created after the version bump (optional). Example:
 ```yaml
 - name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+  uses:  'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -122,7 +122,7 @@ If true, skip pushing any commits or tags created after the version bump (option
 Param to parse the location of the desired package.json (optional). Example:
 ```yaml
 - name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+  uses:  'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     PACKAGEJSON_DIR:  'frontend'
@@ -132,7 +132,7 @@ Param to parse the location of the desired package.json (optional). Example:
 Set a custom target branch to use when bumping the version. Useful in cases such as updating the version on master after a tag has been set (optional). Example:
 ```yaml
 - name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+  uses:  'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -143,7 +143,7 @@ Set a custom target branch to use when bumping the version. Useful in cases such
 Set a custom commit message for version bump commit. Useful for skipping additional workflows run on push. Example:
 ```yaml
 - name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+  uses:  'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -154,7 +154,7 @@ Set a custom commit message for version bump commit. Useful for skipping additio
 **DEPRECATED** Set false you want to avoid pushing the new version tag/package.json. Example:
 ```yaml
 - name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+  uses:  'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Make sure you use the `actions/checkout@v2` action!
 **Migration: Version v9 and up**
 
 Remove the 'actions/setup-node@v1' step from your action.yml file
+
 ```
       - name: 'Setup Node.js'
         uses: 'actions/setup-node@v1'
@@ -23,38 +24,43 @@ Remove the 'actions/setup-node@v1' step from your action.yml file
 
 ### Workflow
 
-* Based on the commit messages, increment the version from the latest release.
-  * If the string "BREAKING CHANGE", "major" or the Attention pattern `refactor!: drop support for Node 6` is found anywhere in any of the commit messages or descriptions the major
+- Based on the commit messages, increment the version from the latest release.
+  - If the string "BREAKING CHANGE", "major" or the Attention pattern `refactor!: drop support for Node 6` is found anywhere in any of the commit messages or descriptions the major
     version will be incremented.
-  * If a commit message begins with the string "feat" or includes "minor" then the minor version will be increased. This works
+  - If a commit message begins with the string "feat" or includes "minor" then the minor version will be increased. This works
     for most common commit metadata for feature additions: `"feat: new API"` and `"feature: new API"`.
-  * If a commit message contains the word "pre-alpha" or "pre-beta" or "pre-rc" then the pre-release version will be increased (for example specifying pre-alpha: 1.6.0-alpha.1 -> 1.6.0-alpha.2 or, specifying pre-beta: 1.6.0-alpha.1 -> 1.6.0-beta.0)
-  * All other changes will increment the patch version.
-* Push the bumped npm version in package.json back into the repo.
-* Push a tag for the new version back into the repo.
+  - If a commit message contains the word "pre-alpha" or "pre-beta" or "pre-rc" then the pre-release version will be increased (for example specifying pre-alpha: 1.6.0-alpha.1 -> 1.6.0-alpha.2 or, specifying pre-beta: 1.6.0-alpha.1 -> 1.6.0-beta.0)
+  - All other changes will increment the patch version.
+- Push the bumped npm version in package.json back into the repo.
+- Push a tag for the new version back into the repo.
 
 ### Usage:
 
+#### **wording:**
 
-#### **wording:** 
-Customize the messages that trigger the version bump. It must be a regex string, case sensitive, coma separated  (optional). Example:
+Customize the messages that trigger the version bump. It must be a regex string, case sensitive, coma separated (optional). Example:
+
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'alphaprime-dev/gh-action-bump-version@master'
+- name: 'Automated Version Bump'
+  uses: 'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
-    minor-wording:  '/add/i,/new/'
-    major-wording:  '/MAJOR/,/cut-major/'
-    patch-wording:  '/patch/,/fixes/'     # Providing patch-wording will override commits
-                                          # defaulting to a patch bump.
-    rc-wording:     '/RELEASE/,/alpha/'
+    minor-wording: '/add/i'
+    major-wording: 'MAJOR'
+    patch-wording:
+      'patch' # Providing patch-wording will override commits
+      # defaulting to a patch bump.
+    rc-wording: 'alpha'
 ```
+
 #### **default:**
-Set a default version bump to use  (optional - defaults to patch). Example:
+
+Set a default version bump to use (optional - defaults to patch). Example:
+
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'alphaprime-dev/gh-action-bump-version@master'
+- name: 'Automated Version Bump'
+  uses: 'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -62,10 +68,12 @@ Set a default version bump to use  (optional - defaults to patch). Example:
 ```
 
 #### **preid:**
-Set a preid value will building prerelease version  (optional - defaults to 'rc'). Example:
+
+Set a preid value will building prerelease version (optional - defaults to 'rc'). Example:
+
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'alphaprime-dev/gh-action-bump-version@master'
+- name: 'Automated Version Bump'
+  uses: 'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -74,65 +82,77 @@ Set a preid value will building prerelease version  (optional - defaults to 'rc'
 ```
 
 #### **tag-prefix:**
-Prefix that is used for the git tag  (optional). Example:
+
+Prefix that is used for the git tag (optional). Example:
+
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'alphaprime-dev/gh-action-bump-version@master'
+- name: 'Automated Version Bump'
+  uses: 'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
-    tag-prefix:  'v'
+    tag-prefix: 'v'
 ```
 
 #### **skip-tag:**
-The tag is not added to the git repository  (optional). Example:
+
+The tag is not added to the git repository (optional). Example:
+
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'alphaprime-dev/gh-action-bump-version@master'
+- name: 'Automated Version Bump'
+  uses: 'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
-    skip-tag:  'true'
+    skip-tag: 'true'
 ```
 
 #### **skip-commit:**
+
 No commit is made after the version is bumped (optional). Must be used in combination with `skip-tag`, since if there's no commit, there's nothing to tag. Example:
+
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'alphaprime-dev/gh-action-bump-version@master'
+- name: 'Automated Version Bump'
+  uses: 'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
-    skip-commit:  'true'
+    skip-commit: 'true'
     skip-tag: 'true'
 ```
 
 #### **skip-push:**
+
 If true, skip pushing any commits or tags created after the version bump (optional). Example:
+
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'alphaprime-dev/gh-action-bump-version@master'
+- name: 'Automated Version Bump'
+  uses: 'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
-    skip-push:  'true'
+    skip-push: 'true'
 ```
 
 #### **PACKAGEJSON_DIR:**
+
 Param to parse the location of the desired package.json (optional). Example:
+
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'alphaprime-dev/gh-action-bump-version@master'
+- name: 'Automated Version Bump'
+  uses: 'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    PACKAGEJSON_DIR:  'frontend'
+    PACKAGEJSON_DIR: 'frontend'
 ```
 
 #### **TARGET-BRANCH:**
+
 Set a custom target branch to use when bumping the version. Useful in cases such as updating the version on master after a tag has been set (optional). Example:
+
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'alphaprime-dev/gh-action-bump-version@master'
+- name: 'Automated Version Bump'
+  uses: 'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -140,10 +160,12 @@ Set a custom target branch to use when bumping the version. Useful in cases such
 ```
 
 #### **commit-message:**
+
 Set a custom commit message for version bump commit. Useful for skipping additional workflows run on push. Example:
+
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'alphaprime-dev/gh-action-bump-version@master'
+- name: 'Automated Version Bump'
+  uses: 'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -151,10 +173,12 @@ Set a custom commit message for version bump commit. Useful for skipping additio
 ```
 
 #### **commit-before:**
+
 Add a command message before commit. Example:
+
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'alphaprime-dev/gh-action-bump-version@master'
+- name: 'Automated Version Bump'
+  uses: 'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:

--- a/README.md
+++ b/README.md
@@ -37,18 +37,18 @@ Remove the 'actions/setup-node@v1' step from your action.yml file
 
 
 #### **wording:** 
-Customize the messages that trigger the version bump. It must be a string, case sensitive, coma separated  (optional). Example:
+Customize the messages that trigger the version bump. It must be a regex string, case sensitive, coma separated  (optional). Example:
 ```yaml
 - name:  'Automated Version Bump'
   uses:  'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
-    minor-wording:  'add,Adds,new'
-    major-wording:  'MAJOR,cut-major'
-    patch-wording:  'patch,fixes'     # Providing patch-wording will override commits
-                                      # defaulting to a patch bump.
-    rc-wording:     'RELEASE,alpha'
+    minor-wording:  '/add/i,/new/'
+    major-wording:  '/MAJOR/,/cut-major/'
+    patch-wording:  '/patch/,/fixes/'     # Providing patch-wording will override commits
+                                          # defaulting to a patch bump.
+    rc-wording:     '/RELEASE/,/alpha/'
 ```
 #### **default:**
 Set a default version bump to use  (optional - defaults to patch). Example:

--- a/README.md
+++ b/README.md
@@ -150,13 +150,13 @@ Set a custom commit message for version bump commit. Useful for skipping additio
     commit-message: 'CI: bumps version to {{version}} [skip ci]'
 ```
 
-#### [DEPRECATED] **push:**
-**DEPRECATED** Set false you want to avoid pushing the new version tag/package.json. Example:
+#### **commit-before:**
+Add a command message before commit. Example:
 ```yaml
 - name:  'Automated Version Bump'
   uses:  'alphaprime-dev/gh-action-bump-version@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
-    push: false
+    commit-before: 'yarn build,yarn auto-test'
 ```

--- a/action.yml
+++ b/action.yml
@@ -13,18 +13,18 @@ inputs:
     required: false
   minor-wording:
     description: 'Words list that trigger a minor version bump'
-    default: 'feat:,minor'
+    default: '/feat:/,/minor/'
     required: false
   major-wording:
     description: 'Words list that trigger a major version bump'
-    default: 'BREAKING CHANGE,major'
+    default: '/BREAKING CHANGE/,/major/'
     required: false
   patch-wording:
     description: 'Words list that trigger a patch version bump'
     required: false
   rc-wording:
     description: 'Words list that trigger a rc version bump'
-    default: 'pre-alpha,pre-beta,pre-rc'
+    default: '/pre-alpha/,/pre-beta/,/pre-rc/'
     required: false
   skip-tag:
     description: 'Avoid to add a TAG to the version update commit'

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: false
   minor-wording:
     description: 'Words list that trigger a minor version bump'
-    default: '/(feat|minor)/i'
+    default: '/feat|minor/i'
     required: false
   major-wording:
     description: 'Words list that trigger a major version bump'

--- a/action.yml
+++ b/action.yml
@@ -13,18 +13,18 @@ inputs:
     required: false
   minor-wording:
     description: 'Words list that trigger a minor version bump'
-    default: '/feat:/,/minor/'
+    default: '/(feat|minor)/i'
     required: false
   major-wording:
     description: 'Words list that trigger a major version bump'
-    default: '/BREAKING CHANGE/,/major/'
+    default: 'BREAKING CHANGE'
     required: false
   patch-wording:
     description: 'Words list that trigger a patch version bump'
     required: false
   rc-wording:
     description: 'Words list that trigger a rc version bump'
-    default: '/pre-alpha/,/pre-beta/,/pre-rc/'
+    default: 'pre-alpha'
     required: false
   skip-tag:
     description: 'Avoid to add a TAG to the version update commit'

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: false
   minor-wording:
     description: 'Words list that trigger a minor version bump'
-    default: 'feat,minor'
+    default: 'feat:,minor'
     required: false
   major-wording:
     description: 'Words list that trigger a major version bump'
@@ -37,6 +37,10 @@ inputs:
   skip-push:
     description: 'If true, skip pushing any commits or tags created after the version bump'
     default: false
+    required: false
+  commit-before:
+    description: 'Add command message before git commit'
+    default: ''
     required: false
   PACKAGEJSON_DIR:
     description: 'Custom dir to the package'

--- a/action.yml
+++ b/action.yml
@@ -17,14 +17,14 @@ inputs:
     required: false
   major-wording:
     description: 'Words list that trigger a major version bump'
-    default: 'BREAKING CHANGE'
+    default: '/BREAKING CHANGE|major/i'
     required: false
   patch-wording:
     description: 'Words list that trigger a patch version bump'
     required: false
   rc-wording:
     description: 'Words list that trigger a rc version bump'
-    default: 'pre-alpha'
+    default: '/pre-(alpha|beta|rc)/i'
     required: false
   skip-tag:
     description: 'Avoid to add a TAG to the version update commit'

--- a/index.js
+++ b/index.js
@@ -29,8 +29,7 @@ const workspace = process.env.GITHUB_WORKSPACE;
   const isVersionBump = messages.find((message) => commitMessageRegex.test(message)) !== undefined;
 
   if (isVersionBump) {
-    exitSuccess('No action necessary because we found a previous bump!');
-    return;
+    return exitSuccess('No action necessary because we found a previous bump!');
   }
 
   // input wordings for MAJOR, MINOR, PATCH, PRE-RELEASE
@@ -40,7 +39,9 @@ const workspace = process.env.GITHUB_WORKSPACE;
   const patchWords = process.env['INPUT_PATCH-WORDING'] ? process.env['INPUT_PATCH-WORDING'].split(',') : null;
   const preReleaseWords = process.env['INPUT_RC-WORDING'] ? process.env['INPUT_RC-WORDING'].split(',') : null;
 
-  console.log('config words:', { majorWords, minorWords, patchWords, preReleaseWords });
+  const beforeCommits = process.env['INPUT_COMMIT-BEFORE'] ? process.env['INPUT_COMMIT-BEFORE'].split(',') : null;
+
+  console.log('config words:', { majorWords, minorWords, patchWords, preReleaseWords, beforeCommits });
 
   // get default version bump
   let version = process.env.INPUT_DEFAULT;
@@ -49,19 +50,20 @@ const workspace = process.env.GITHUB_WORKSPACE;
   let preid = process.env.INPUT_PREID;
 
   // case: if wording for MAJOR found
+  const majorDefaultRegex = /^([a-zA-Z]+)(\(.+\))?(\!)\:/;
   if (
     messages.some(
-      (message) => /^([a-zA-Z]+)(\(.+\))?(\!)\:/.test(message) || majorWords.some((word) => message.includes(word)),
+      (message) => majorDefaultRegex.test(message) || majorWords.some((word) => testRegex(message, word)),
     )
   ) {
     version = 'major';
   }
   // case: if wording for MINOR found
-  else if (messages.some((message) => minorWords.some((word) => message.includes(word)))) {
+  else if (messages.some((message) => minorWords.some((word) => testRegex(message, word)))) {
     version = 'minor';
   }
   // case: if wording for PATCH found
-  else if (patchWords && messages.some((message) => patchWords.some((word) => message.includes(word)))) {
+  else if (patchWords && messages.some((message) => patchWords.some((word) => testRegex(message, word)))) {
     version = 'patch';
   }
   // case: if wording for PRE-RELEASE found
@@ -69,7 +71,7 @@ const workspace = process.env.GITHUB_WORKSPACE;
     preReleaseWords &&
     messages.some((message) =>
       preReleaseWords.some((word) => {
-        if (message.includes(word)) {
+        if (testRegex(message, word)) {
           foundWord = word;
           return true;
         } else {
@@ -91,30 +93,27 @@ const workspace = process.env.GITHUB_WORKSPACE;
   if (
     version === 'prerelease' &&
     preReleaseWords &&
-    !messages.some((message) => preReleaseWords.some((word) => message.includes(word)))
+    !messages.some((message) => preReleaseWords.some((word) => testRegex(message, word)))
   ) {
     version = null;
   }
 
   // case: if default=prerelease, but rc-wording is NOT set
   if (version === 'prerelease' && preid) {
-    version = 'prerelease';
-    version = `${version} --preid=${preid}`;
+    version = `prerelease --preid=${preid}`;
   }
 
   console.log('version action after final decision:', version);
 
   // case: if nothing of the above matches
   if (version === null) {
-    exitSuccess('No version keywords found, skipping bump.');
-    return;
+    return exitSuccess('No version keywords found, skipping bump.');
   }
 
   // case: if user sets push to false, to skip pushing new tag/package.json
   const push = process.env['INPUT_PUSH'];
   if (push === 'false' || push === false) {
-    exitSuccess('User requested to skip pushing new tag and package.json. Finished.');
-    return;
+    return exitSuccess('User requested to skip pushing new tag and package.json. Finished.');
   }
 
   // GIT logic
@@ -147,6 +146,13 @@ const workspace = process.env.GITHUB_WORKSPACE;
     let newVersion = execSync(`npm version --git-tag-version=false ${version}`).toString().trim().replace(/^v/, '');
     newVersion = `${tagPrefix}${newVersion}`;
     if (process.env['INPUT_SKIP-COMMIT'] !== 'true') {
+      if (beforeCommits) {
+        for (const commit of beforeCommits) {
+          const commitArr = commit.split(' ');
+          const args = commitArr.slice(1);
+          await runInWorkspace(commitArr[0], args);
+        }
+      }
       await runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);
     }
 
@@ -164,6 +170,13 @@ const workspace = process.env.GITHUB_WORKSPACE;
     try {
       // to support "actions/checkout@v1"
       if (process.env['INPUT_SKIP-COMMIT'] !== 'true') {
+        if (beforeCommits) {
+        for (const commit of beforeCommits) {
+          const commitArr = commit.split(' ');
+          const args = commitArr.slice(1);
+          await runInWorkspace(commitArr[0], args);
+        }
+      }
         await runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);
       }
     } catch (e) {
@@ -236,4 +249,10 @@ function runInWorkspace(command, args) {
     });
   });
   //return execa(command, args, { cwd: workspace });
+}
+
+function testRegex(text, regexStr) {
+  const parts = /\/(.*)\/(.*)/.exec(regexStr);
+  const regex = new RegExp(parts[1], parts[2]);
+  return text.test(regex);
 }

--- a/index.js
+++ b/index.js
@@ -254,5 +254,5 @@ function runInWorkspace(command, args) {
 function testRegex(text, regexStr) {
   const parts = /\/(.*)\/(.*)/.exec(regexStr);
   const regex = new RegExp(parts[1], parts[2]);
-  return text.test(regex);
+  return regex.test(text);
 }

--- a/index.js
+++ b/index.js
@@ -69,8 +69,10 @@ const workspace = process.env.GITHUB_WORKSPACE;
   else if (matchMinorWord) version = 'minor';
   else if (patchWord && matchPatchWord) version = 'patch';
   else if (preReleaseWord) {
-    if (matchPreReleaseWord) {
-      foundWord = preReleaseWord;
+    const message = messages.find((message) => matchPattern(message, preReleaseWord));
+    if (message) {
+      const wordRegExp = convertToRegExp(preReleaseWord);
+      foundWord = message.match(wordRegExp)[0];
       preid = foundWord.split('-')[1];
       version = 'prerelease';
     }

--- a/index.js
+++ b/index.js
@@ -39,9 +39,9 @@ const workspace = process.env.GITHUB_WORKSPACE;
   const patchWord = process.env['INPUT_PATCH-WORDING'] || '';
   const preReleaseWord = process.env['INPUT_RC-WORDING'] || '';
 
-  const beforeCommits = process.env['INPUT_COMMIT-BEFORE'] ? process.env['INPUT_COMMIT-BEFORE'].split(',') : null;
+  const beforeCommit = process.env['INPUT_COMMIT-BEFORE'] ? process.env['INPUT_COMMIT-BEFORE'].split(',') : null;
 
-  console.log('config words:', { majorWord, minorWord, patchWord, preReleaseWord, beforeCommits });
+  console.log('config words:', { majorWord, minorWord, patchWord, preReleaseWord, beforeCommit });
 
   // get default version bump
   let version = process.env.INPUT_DEFAULT;
@@ -134,12 +134,10 @@ const workspace = process.env.GITHUB_WORKSPACE;
     let newVersion = execSync(`npm version --git-tag-version=false ${version}`).toString().trim().replace(/^v/, '');
     newVersion = `${tagPrefix}${newVersion}`;
     if (process.env['INPUT_SKIP-COMMIT'] !== 'true') {
-      if (beforeCommits) {
-        for (const commit of beforeCommits) {
-          const commitArr = commit.split(' ');
-          const args = commitArr.slice(1);
-          await runInWorkspace(commitArr[0], args);
-        }
+      if (beforeCommit) {
+        const commitArr = beforeCommit.split(' ');
+        const args = commitArr.slice(1);
+        await runInWorkspace(commitArr[0], args);
       }
       await runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);
     }
@@ -158,12 +156,10 @@ const workspace = process.env.GITHUB_WORKSPACE;
     try {
       // to support "actions/checkout@v1"
       if (process.env['INPUT_SKIP-COMMIT'] !== 'true') {
-        if (beforeCommits) {
-          for (const commit of beforeCommits) {
-            const commitArr = commit.split(' ');
-            const args = commitArr.slice(1);
-            await runInWorkspace(commitArr[0], args);
-          }
+        if (beforeCommit) {
+          const commitArr = beforeCommit.split(' ');
+          const args = commitArr.slice(1);
+          await runInWorkspace(commitArr[0], args);
         }
         await runInWorkspace('git', ['commit', '-a', '-m', commitMessage.replace(/{{version}}/g, newVersion)]);
       }

--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
   "version": "9.0.13",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/phips28/gh-action-bump-version.git"
+    "url": "git+https://github.com/alphaprime-dev/gh-action-bump-version.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/phips28/gh-action-bump-version/issues"
+    "url": "https://github.com/alphaprime-dev/gh-action-bump-version/issues"
   },
-  "homepage": "https://github.com/phips28/gh-action-bump-version#readme",
+  "homepage": "https://github.com/alphaprime-dev/gh-action-bump-version#readme",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/tests/end-to-end/config.yaml
+++ b/tests/end-to-end/config.yaml
@@ -20,12 +20,24 @@ suites:
       - message: feat
         expected:
           version: 1.1.0
+      - message: minor
+        expected:
+          version: 1.2.0
       - message: BREAKING CHANGE
         expected:
           version: 2.0.0
+      - message: major
+        expected:
+          version: 3.0.0
       - message: pre-alpha
         expected:
-          version: 2.0.1-alpha.0
+          version: 3.0.1-alpha.0
+      - message: pre-beta
+        expected:
+          version: 3.0.1-beta.0
+      - message: pre-rc
+        expected:
+          version: 3.0.1-rc.0
   - name: no-push
     yaml:
       name: Do Nothing
@@ -45,7 +57,7 @@ suites:
     tests:
       - message: no keywords
         expected:
-          version: 2.0.1-alpha.0
+          version: 3.0.1-rc.0
   - name: custom-wording
     yaml:
       name: Bump Version (Custom Wording)
@@ -67,13 +79,13 @@ suites:
     tests:
       - message: custom-minor
         expected:
-          version: 2.1.0
+          version: 3.1.0
       - message: custom-major
         expected:
-          version: 3.0.0
+          version: 4.0.0
       - message: custom-pre
         expected:
-          version: 3.0.1-pre.0
+          version: 4.0.1-pre.0
   - name: null-default
     yaml:
       name: Bump Version (Default="Minor")
@@ -94,10 +106,10 @@ suites:
     tests:
       - message: no hint
         expected:
-          version: 3.1.0
+          version: 4.1.0
       - message: patch
         expected:
-          version: 3.1.1
+          version: 4.1.1
   - name: custom-tag-prefix
     yaml:
       name: Bump Version (Custom Tag Prefix)
@@ -117,8 +129,8 @@ suites:
     tests:
       - message: no keywords
         expected:
-          version: 3.1.2
-          tag: v3.1.2
+          version: 4.1.2
+          tag: v4.1.2
   - name: target-branch
     yaml:
       name: Bump Version (Target Branch)
@@ -141,9 +153,9 @@ suites:
     tests:
       - message: no keywords
         expected:
-          version: 3.1.3
+          version: 4.1.3
           branch: other-branch
-          
+
   # the test are not working (https://github.com/phips28/gh-action-bump-version/pull/139)
   # - name: skip-commit
   #   yaml:

--- a/tests/end-to-end/config.yaml
+++ b/tests/end-to-end/config.yaml
@@ -20,24 +20,12 @@ suites:
       - message: feat
         expected:
           version: 1.1.0
-      - message: minor
-        expected:
-          version: 1.2.0
       - message: BREAKING CHANGE
         expected:
           version: 2.0.0
-      - message: major
-        expected:
-          version: 3.0.0
       - message: pre-alpha
         expected:
-          version: 3.0.1-alpha.0
-      - message: pre-beta
-        expected:
-          version: 3.0.1-beta.0
-      - message: pre-rc
-        expected:
-          version: 3.0.1-rc.0
+          version: 2.0.1-alpha.0
   - name: no-push
     yaml:
       name: Do Nothing
@@ -57,7 +45,7 @@ suites:
     tests:
       - message: no keywords
         expected:
-          version: 3.0.1-rc.0
+          version: 2.0.1-alpha.0
   - name: custom-wording
     yaml:
       name: Bump Version (Custom Wording)
@@ -79,13 +67,13 @@ suites:
     tests:
       - message: custom-minor
         expected:
-          version: 3.1.0
+          version: 2.1.0
       - message: custom-major
         expected:
-          version: 4.0.0
+          version: 3.0.0
       - message: custom-pre
         expected:
-          version: 4.0.1-pre.0
+          version: 3.0.1-pre.0
   - name: null-default
     yaml:
       name: Bump Version (Default="Minor")
@@ -106,10 +94,10 @@ suites:
     tests:
       - message: no hint
         expected:
-          version: 4.1.0
+          version: 3.1.0
       - message: patch
         expected:
-          version: 4.1.1
+          version: 3.1.1
   - name: custom-tag-prefix
     yaml:
       name: Bump Version (Custom Tag Prefix)
@@ -129,8 +117,8 @@ suites:
     tests:
       - message: no keywords
         expected:
-          version: 4.1.2
-          tag: v4.1.2
+          version: 3.1.2
+          tag: v3.1.2
   - name: target-branch
     yaml:
       name: Bump Version (Target Branch)
@@ -153,7 +141,7 @@ suites:
     tests:
       - message: no keywords
         expected:
-          version: 4.1.3
+          version: 3.1.3
           branch: other-branch
   - name: skip-commit
     yaml:
@@ -174,8 +162,8 @@ suites:
     tests:
       - message: no keywords
         expected:
-          version: 4.1.4
-          message: 'ci: version bump to 4.1.3'
+          version: 3.1.4
+          message: 'ci: version bump to 3.1.3'
 
 actionFiles:
   - index.js

--- a/tests/end-to-end/config.yaml
+++ b/tests/end-to-end/config.yaml
@@ -143,27 +143,29 @@ suites:
         expected:
           version: 3.1.3
           branch: other-branch
-  - name: skip-commit
-    yaml:
-      name: Bump Version (Skip Commit)
-      on:
-        push:
-      jobs:
-        bump-version:
-          runs-on: ubuntu-latest
-          steps:
-            - uses: actions/checkout@v2
-            - id: version-bump
-              uses: ./action
-              env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                skip-commit: true
-    tests:
-      - message: no keywords
-        expected:
-          version: 3.1.4
-          message: 'ci: version bump to 3.1.3'
+          
+  # the test are not working (https://github.com/phips28/gh-action-bump-version/pull/139)
+  # - name: skip-commit
+  #   yaml:
+  #     name: Bump Version (Skip Commit)
+  #     on:
+  #       push:
+  #     jobs:
+  #       bump-version:
+  #         runs-on: ubuntu-latest
+  #         steps:
+  #           - uses: actions/checkout@v2
+  #           - id: version-bump
+  #             uses: ./action
+  #             env:
+  #               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #             with:
+  #               skip-commit: true
+  #   tests:
+  #     - message: no keywords
+  #       expected:
+  #         version: 3.1.4
+  #         message: 'ci: version bump to 3.1.3'
 
 actionFiles:
   - index.js


### PR DESCRIPTION
## Changes

> 기존 `gh-action-bump-version`에 아래와 같은 기능을 추가하였습니다.
 
### 1. 정규 표현식 넘기기
- minor, major, fetch, preRelease word에 정규표현식을 넘길 수 있도록 하였습니다.
- 함수의 경우, 구두로 전달해주신 release-drafter의 코드를 사용하였습니다.
```js
function matchPattern(message, word) {
  const regex = convertToRegExp(word);
  return regex.test(message);
}

function convertToRegExp(text) {
  if (text.match(/^\/.+\/[gmixXsuUAJ]*$/)) {
    return regexParser(text);
  } else return new RegExp(text, 'g');
}

function regexParser(text) {  // regexParser 라이브러리 코드 사용
  const m = text.match(/(\/?)(.+)\1([a-z]*)/i);
  if (m[3] && !/^(?!.*?(.).*?\1)[gmixXsuUAJ]+$/.test(m[3])) {
    return RegExp(text);
  } else {
    return new RegExp(m[2], m[3]);
  }
}
```

<br/><br/>

### 2. commit-before 추가하기
- 커밋이 발생하기 전에 특정 명령어 실행을 위한 목적으로 추가하였습니다.
- 기존 코드에서 제공하던 `runInWorkspace`를 사용할 수 있도록 하였습니다.
```js
if (beforeCommits) {
    for (const commit of beforeCommits) {
      const commitArr = commit.split(' ');
      const args = commitArr.slice(1);
      await runInWorkspace(commitArr[0], args);
    }
  }
```

<br/><br/>

### 3. 테스트
- 테스트 17개 중 16개는 통과가 됐으나, `skip-commit`의 경우 계속적으로 실패합니다.
- 원인을 찾기 위해 `phips28/gh-action-bump-version`을 클론받아 테스트를 해본 결과 동일하게 `skip-commit`이 실패하였습니다.

<img width="813" alt="스크린샷 2021-12-22 오후 8 43 59" src="https://user-images.githubusercontent.com/37934668/147088065-68667e19-cde4-4c44-af88-355d3a7250df.png">


<br/>

- 이에 레파지토리의 질문을 보니 **작동하지 않는 테스트**라고 합니다! (<a href="https://github.com/phips28/gh-action-bump-version/pull/139">질문보기</a>)
- 해당 테스트 지우는 게 좋을 지 의견을 묻고 싶습니다 :)

<img width="1158" alt="스크린샷 2021-12-22 오후 8 41 57" src="https://user-images.githubusercontent.com/37934668/147087669-5ad86b80-d43e-4e94-946e-fc1b0b09bf13.png">





