### PR TITLE
chore: delete split on beforeCommit

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const workspace = process.env.GITHUB_WORKSPACE;
   const patchWord = process.env['INPUT_PATCH-WORDING'] || '';
   const preReleaseWord = process.env['INPUT_RC-WORDING'] || '';
 
-  const beforeCommit = process.env['INPUT_COMMIT-BEFORE'] ? process.env['INPUT_COMMIT-BEFORE'].split(',') : null;
+  const beforeCommit = process.env['INPUT_COMMIT-BEFORE'] || null;
 
   console.log('config words:', { majorWord, minorWord, patchWord, preReleaseWord, beforeCommit });
 


### PR DESCRIPTION
## Changes 
- beforeCommit에서 `split(,)`를 지우지 않아 버그가 발생해 해당 코드를 수정하였습니다.

```js
// before
const beforeCommit = process.env['INPUT_COMMIT-BEFORE'] ? process.env['INPUT_COMMIT-BEFORE'].split(',') : null;
```
```js
// after
const beforeCommit = process.env['INPUT_COMMIT-BEFORE'] || null;
```

<br/>

## Test
- `KumJungMin/alpha-chart`에서 해당 브렌치의 액션을 추가하여 테스트한 결과 버전 업이 작동되었습니다.
```js
// bump-version.yml

- name: 'Automated Version Bump'
   id: version-bump
   uses: 'alphaprime-dev/gh-action-bump-version@feature/commit-before-split' // 수정하여 테스트

```